### PR TITLE
[JENKINS-32507] Cannot create Zephyr Server

### DIFF
--- a/src/main/java/com/thed/zephyr/jenkins/reporter/ZeeDescriptor.java
+++ b/src/main/java/com/thed/zephyr/jenkins/reporter/ZeeDescriptor.java
@@ -179,12 +179,12 @@ public final class ZeeDescriptor extends BuildStepDescriptor<Publisher> {
 		Map<Boolean, String> credentialValidationResultMap;
 		RestClient restClient = null;
 		try {
-	    	restClient = getRestclient(serverAddress);
 
 			if (!zephyrURL.startsWith("http")) {
                 return FormValidation.error(zephyrURL);
             }
 
+			restClient = new RestClient(serverAddress, username, password);
 			if (!ServerInfo.findServerAddressIsValidZephyrURL(restClient)) {
                 return FormValidation.error("This is not a valid Zephyr Server");
             }


### PR DESCRIPTION
[JENKINS-32507](https://issues.jenkins-ci.org/browse/JENKINS-32507)

The current implementation reuse a method that need a server configured if there is no server configured before, it fails, so, you only could add servers if you have one configured.

I have solved it instanciated a RestClient directly.

@reviewbybees 
